### PR TITLE
Feature: support batch deployment strategy

### DIFF
--- a/module-controller/api/v1alpha1/moduledeployment_types.go
+++ b/module-controller/api/v1alpha1/moduledeployment_types.go
@@ -94,7 +94,7 @@ type ModuleDeploymentCondition struct {
 
 type ModuleSchedulingStrategy struct {
 	// +kubebuilder:validation:Enum={"scatter","stacking"}
-	// +kubebuilder:default=scatter
+	// +kubebuilder:default="scatter"
 	SchedulingType ModuleSchedulingType `json:"schedulingType"`
 	//MaxModuleCount int                  `json:"maxModuleCount"`
 }

--- a/module-controller/api/v1alpha1/moduledeployment_types.go
+++ b/module-controller/api/v1alpha1/moduledeployment_types.go
@@ -54,8 +54,8 @@ const (
 type ModuleSchedulingType string
 
 const (
-	Scatter  ModuleSchedulingType = "Scatter"
-	Stacking ModuleSchedulingType = "Stacking"
+	Scatter  ModuleSchedulingType = "scatter"
+	Stacking ModuleSchedulingType = "stacking"
 )
 
 type ReleaseStatus struct {
@@ -93,6 +93,8 @@ type ModuleDeploymentCondition struct {
 }
 
 type ModuleSchedulingStrategy struct {
+	// +kubebuilder:validation:Enum={"scatter","stacking"}
+	// +kubebuilder:default=scatter
 	SchedulingType ModuleSchedulingType `json:"schedulingType"`
 	MaxModuleCount int                  `json:"maxModuleCount"`
 }

--- a/module-controller/api/v1alpha1/moduledeployment_types.go
+++ b/module-controller/api/v1alpha1/moduledeployment_types.go
@@ -96,7 +96,7 @@ type ModuleSchedulingStrategy struct {
 	// +kubebuilder:validation:Enum={"scatter","stacking"}
 	// +kubebuilder:default=scatter
 	SchedulingType ModuleSchedulingType `json:"schedulingType"`
-	MaxModuleCount int                  `json:"maxModuleCount"`
+	//MaxModuleCount int                  `json:"maxModuleCount"`
 }
 
 type ModuleDeploymentStrategy struct {

--- a/module-controller/api/v1alpha1/moduledeployment_types.go
+++ b/module-controller/api/v1alpha1/moduledeployment_types.go
@@ -134,7 +134,7 @@ type ModuleDeploymentSpec struct {
 	// +optional
 	Pause bool `json:"pause,omitempty"`
 
-	OperationStrategy ModuleDeploymentStrategy `json:"strategy,omitempty"`
+	OperationStrategy ModuleDeploymentStrategy `json:"operationStrategy,omitempty"`
 
 	SchedulingStrategy ModuleSchedulingStrategy `json:"schedulingStrategy,omitempty"`
 }

--- a/module-controller/api/v1alpha1/moduledeployment_types.go
+++ b/module-controller/api/v1alpha1/moduledeployment_types.go
@@ -46,9 +46,9 @@ const (
 	ModuleDeploymentReleaseProgressWaitingForConfirmation ReleaseProgress = "WaitingForConfirmation"
 	ModuleDeploymentReleaseProgressExecuting              ReleaseProgress = "Executing"
 	ModuleDeploymentReleaseProgressPaused                 ReleaseProgress = "Paused"
-	CafeDeploymentReleaseProgressCompleted                ReleaseProgress = "Completed"
-	CafeDeploymentReleaseProgressAborted                  ReleaseProgress = "Aborted"
-	CafeDeploymentReleaseProgressTermed                   ReleaseProgress = "Terminated"
+	ModuleDeploymentReleaseProgressCompleted              ReleaseProgress = "Completed"
+	ModuleDeploymentReleaseProgressAborted                ReleaseProgress = "Aborted"
+	ModuleDeploymentReleaseProgressTermed                 ReleaseProgress = "Terminated"
 )
 
 type ModuleSchedulingType string

--- a/module-controller/config/crd/bases/serverless.alipay.com_moduledeployments.yaml
+++ b/module-controller/config/crd/bases/serverless.alipay.com_moduledeployments.yaml
@@ -80,8 +80,6 @@ spec:
                 type: integer
               schedulingStrategy:
                 properties:
-                  maxModuleCount:
-                    type: integer
                   schedulingType:
                     default: scatter
                     enum:
@@ -89,7 +87,6 @@ spec:
                     - stacking
                     type: string
                 required:
-                - maxModuleCount
                 - schedulingType
                 type: object
               template:

--- a/module-controller/config/crd/bases/serverless.alipay.com_moduledeployments.yaml
+++ b/module-controller/config/crd/bases/serverless.alipay.com_moduledeployments.yaml
@@ -42,6 +42,28 @@ spec:
               minReadySeconds:
                 format: int32
                 type: integer
+              operationStrategy:
+                properties:
+                  batchCount:
+                    format: int32
+                    type: integer
+                  grayTimeBetweenBatchSeconds:
+                    format: int32
+                    type: integer
+                  maxUnavailable:
+                    anyOf:
+                    - type: integer
+                    - type: string
+                    x-kubernetes-int-or-string: true
+                  needConfirm:
+                    type: boolean
+                  upgradeType:
+                    type: string
+                  useBeta:
+                    type: boolean
+                required:
+                - upgradeType
+                type: object
               pause:
                 description: Indicates that the moduleDeployment is paused and will
                   not be processed by the moduleDeployment controller.
@@ -65,28 +87,6 @@ spec:
                 required:
                 - maxModuleCount
                 - schedulingType
-                type: object
-              strategy:
-                properties:
-                  batchCount:
-                    format: int32
-                    type: integer
-                  grayTimeBetweenBatchSeconds:
-                    format: int32
-                    type: integer
-                  maxUnavailable:
-                    anyOf:
-                    - type: integer
-                    - type: string
-                    x-kubernetes-int-or-string: true
-                  needConfirm:
-                    type: boolean
-                  upgradeType:
-                    type: string
-                  useBeta:
-                    type: boolean
-                required:
-                - upgradeType
                 type: object
               template:
                 properties:

--- a/module-controller/config/crd/bases/serverless.alipay.com_moduledeployments.yaml
+++ b/module-controller/config/crd/bases/serverless.alipay.com_moduledeployments.yaml
@@ -83,6 +83,10 @@ spec:
                   maxModuleCount:
                     type: integer
                   schedulingType:
+                    default: scatter
+                    enum:
+                    - scatter
+                    - stacking
                     type: string
                 required:
                 - maxModuleCount

--- a/module-controller/config/samples/dynamic-stock-deployment.yaml
+++ b/module-controller/config/samples/dynamic-stock-deployment.yaml
@@ -11,6 +11,7 @@ spec:
     metadata:
       labels:
         app: dynamic-stock
+        maxModuleCount: 10
     spec:
       containers:
         - name: dynamic-stock-container

--- a/module-controller/config/samples/dynamic-stock-deployment.yaml
+++ b/module-controller/config/samples/dynamic-stock-deployment.yaml
@@ -11,7 +11,7 @@ spec:
     metadata:
       labels:
         app: dynamic-stock
-        maxModuleCount: 10
+        maxModuleCount: "10"
     spec:
       containers:
         - name: dynamic-stock-container

--- a/module-controller/config/samples/module-deployment_v1alpha1_moduledeployment.yaml
+++ b/module-controller/config/samples/module-deployment_v1alpha1_moduledeployment.yaml
@@ -23,4 +23,4 @@ spec:
     useBeta: false
     batchCount: 3
   schedulingStrategy:
-    maxModuleCount: 10
+    schedulingType: scatter

--- a/module-controller/config/samples/module-deployment_v1alpha1_moduledeployment.yaml
+++ b/module-controller/config/samples/module-deployment_v1alpha1_moduledeployment.yaml
@@ -16,10 +16,12 @@ spec:
         name: dynamic-provider
         version: '1.0.0'
         url: http://serverless-opensource.oss-cn-shanghai.aliyuncs.com/module-packages/stable/dynamic-provider-1.0.0-ark-biz.jar
-  replicas: 1
-  strategy:
+  replicas: 3
+  operationStrategy:
     upgradeType: installAndUninstall
     needConfirm: true
     useBeta: false
     batchCount: 3
+  schedulingStrategy:
+    maxModuleCount: 10
 

--- a/module-controller/config/samples/module-deployment_v1alpha1_moduledeployment.yaml
+++ b/module-controller/config/samples/module-deployment_v1alpha1_moduledeployment.yaml
@@ -24,4 +24,3 @@ spec:
     batchCount: 3
   schedulingStrategy:
     maxModuleCount: 10
-

--- a/module-controller/internal/arklet/arklet_client.go
+++ b/module-controller/internal/arklet/arklet_client.go
@@ -4,12 +4,16 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
-	"github.com/sofastack/sofa-serverless/api/v1alpha1"
 	"io"
 	"net/http"
-	"sigs.k8s.io/controller-runtime/pkg/log"
+	"net/http/httptest"
 	"strconv"
 	"sync"
+
+	"k8s.io/utils/env"
+	"sigs.k8s.io/controller-runtime/pkg/log"
+
+	"github.com/sofastack/sofa-serverless/api/v1alpha1"
 )
 
 const (
@@ -56,6 +60,18 @@ func init() {
 	uninstallPath = DefaultUninstallPath
 	switchPath = DefaultSwitchPath
 	port = DefaultPort
+
+	testEnv, _ := env.GetBool("test", false)
+	if testEnv {
+		svr := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			data := ArkletResponse{
+				Code: Success,
+			}
+			w.Header().Set("Content-Type", "application/json")
+			json.NewEncoder(w).Encode(data)
+		}))
+		MockClient(svr.URL)
+	}
 }
 
 func MockClient(customMockUrl string) {

--- a/module-controller/internal/constants/label/well_known_labels.go
+++ b/module-controller/internal/constants/label/well_known_labels.go
@@ -13,6 +13,8 @@ const (
 
 	ModuleDeploymentLabel = "serverless.alipay.com/module-deployment"
 
+	ModuleReplicasetReversionLabel = "serverless.alipay.com/module-replicaset-reversion"
+
 	DeleteModuleLabel = "serverless.alipay.com/delete-module"
 
 	ModuleInstanceCount = "serverless.alipay.com/module-instance-count"

--- a/module-controller/internal/constants/label/well_known_labels.go
+++ b/module-controller/internal/constants/label/well_known_labels.go
@@ -13,7 +13,7 @@ const (
 
 	ModuleDeploymentLabel = "serverless.alipay.com/module-deployment"
 
-	ModuleReplicasetReversionLabel = "serverless.alipay.com/module-replicaset-reversion"
+	ModuleReplicasetRevisionLabel = "serverless.alipay.com/module-replicaset-revision"
 
 	DeleteModuleLabel = "serverless.alipay.com/delete-module"
 

--- a/module-controller/internal/controller/module_controller.go
+++ b/module-controller/internal/controller/module_controller.go
@@ -164,20 +164,6 @@ func (r *ModuleReconciler) handleTerminatingModuleInstance(ctx context.Context, 
 					return ctrl.Result{}, err
 				}
 
-				// update moduleReplicaset status
-				if replicasetName := module.Labels[label.ModuleReplicasetLabel]; replicasetName != "" {
-					for i := 0; i < 3; i++ {
-						replicaset := &v1alpha1.ModuleReplicaSet{}
-						err := r.Get(ctx, types.NamespacedName{Namespace: module.Namespace, Name: replicasetName}, replicaset)
-						if err != nil {
-							continue
-						}
-						replicaset.Status.Replicas -= 1
-						if err = r.Status().Update(ctx, replicaset); err != nil {
-							continue
-						}
-					}
-				}
 			} else {
 				log.Log.Info("pod not exist", "moduleName", module.Spec.Module.Name, "module", module.Name)
 			}

--- a/module-controller/internal/controller/module_controller.go
+++ b/module-controller/internal/controller/module_controller.go
@@ -163,6 +163,21 @@ func (r *ModuleReconciler) handleTerminatingModuleInstance(ctx context.Context, 
 					log.Log.Error(err, "Failed post module", "moduleName", module.Spec.Module.Name)
 					return ctrl.Result{}, err
 				}
+
+				// update moduleReplicaset status
+				if replicasetName := module.Labels[label.ModuleReplicasetLabel]; replicasetName != "" {
+					for i := 0; i < 3; i++ {
+						replicaset := &v1alpha1.ModuleReplicaSet{}
+						err := r.Get(ctx, types.NamespacedName{Namespace: module.Namespace, Name: replicasetName}, replicaset)
+						if err != nil {
+							continue
+						}
+						replicaset.Status.Replicas -= 1
+						if err = r.Status().Update(ctx, replicaset); err != nil {
+							continue
+						}
+					}
+				}
 			} else {
 				log.Log.Info("pod not exist", "moduleName", module.Spec.Module.Name, "module", module.Name)
 			}
@@ -309,7 +324,7 @@ func (r *ModuleReconciler) handleUpgradingModuleInstance(ctx context.Context, mo
 		return ctrl.Result{}, nil
 	}
 
-	// update status
+	// update module status
 	module.Status.Status = v1alpha1.ModuleInstanceStatusCompleting
 	module.Status.LastTransitionTime = metav1.Now()
 	log.Log.Info(fmt.Sprintf("%s%s", "module status change to ", v1alpha1.ModuleInstanceStatusCompleting))

--- a/module-controller/internal/controller/moduledeployment_controller.go
+++ b/module-controller/internal/controller/moduledeployment_controller.go
@@ -306,7 +306,6 @@ func (r *ModuleDeploymentReconciler) generateModuleReplicas(moduleDeployment *mo
 		},
 		Spec: moduledeploymentv1alpha1.ModuleReplicaSetSpec{
 			Selector:        *deployment.Spec.Selector,
-			Replicas:        moduleDeployment.Spec.Replicas,
 			Template:        moduleDeployment.Spec.Template,
 			MinReadySeconds: moduleDeployment.Spec.MinReadySeconds,
 		},

--- a/module-controller/internal/controller/moduledeployment_controller.go
+++ b/module-controller/internal/controller/moduledeployment_controller.go
@@ -231,28 +231,18 @@ func (r *ModuleDeploymentReconciler) createOrGetModuleReplicas(ctx context.Conte
 					maxVersion = version
 					newRS = &replicaSetList.Items[j]
 					oldRSs = oldRSs[:len(oldRSs)-1]
-				} else {
-					panic(fmt.Sprintf("maxVersion: %v, version: %v", maxVersion, version))
 				}
 			}
 			// todo: 批发发布没有完成时不允许改变 module 版本，需要webhook支持限制在批次发布过程中 module 版本变更
 			// 此处默认当 Module 发生版本变化时，已经完成上个版本的批次发布
-			if newRS != nil && !isModuleChanges(moduleDeployment.Spec.Template.Spec.Module, newRS.Spec.Template.Spec.Module) {
+			if !isModuleChanges(moduleDeployment.Spec.Template.Spec.Module, newRS.Spec.Template.Spec.Module) {
 				return newRS, oldRSs, nil
 			}
 			oldRSs = append(oldRSs, newRS)
-			if newRS == nil {
-				panic(fmt.Sprintf("items cnt: %v", len(replicaSetList.Items)))
-			}
 			log.Log.Info("module has changed, need create a new replicaset")
-			log.Log.Info(fmt.Sprintf("%v", moduleDeployment.Spec.Template.Spec.Module))
-			log.Log.Info(fmt.Sprintf("%v", newRS.Spec.Template.Spec.Module))
 		}
 
-		log.Log.Info(fmt.Sprintf("xxxxx module replicaset is cnt: %v", len(replicaSetList.Items)))
-
 		// create a new moduleReplicaset
-
 		moduleReplicaSet, err := r.createNewReplicaSet(ctx, moduleDeployment, maxVersion+1)
 		if err != nil {
 			continue

--- a/module-controller/internal/controller/moduledeployment_controller_suit_test.go
+++ b/module-controller/internal/controller/moduledeployment_controller_suit_test.go
@@ -136,6 +136,10 @@ func prepareModuleDeployment(namespace, moduleDeploymentName string) v1alpha1.Mo
 					},
 				},
 			},
+			SchedulingStrategy: v1alpha1.ModuleSchedulingStrategy{
+				SchedulingType: v1alpha1.Scatter,
+				MaxModuleCount: 10,
+			},
 		},
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      moduleDeploymentName,

--- a/module-controller/internal/controller/moduledeployment_controller_suit_test.go
+++ b/module-controller/internal/controller/moduledeployment_controller_suit_test.go
@@ -67,7 +67,11 @@ var _ = Describe("ModuleDeployment Controller", func() {
 				maxVersion := 0
 				var newRS *moduledeploymentv1alpha1.ModuleReplicaSet
 				for i := 0; i < len(replicaSetList.Items); i++ {
-					if version := getVersion(&replicaSetList.Items[i]); version > maxVersion {
+					version, err := getVersion(&replicaSetList.Items[i])
+					if err != nil {
+						return false
+					}
+					if version > maxVersion {
 						maxVersion = version
 						newRS = &replicaSetList.Items[i]
 					}
@@ -75,7 +79,7 @@ var _ = Describe("ModuleDeployment Controller", func() {
 
 				// the replicas of old replicaset must be zero
 				for i := 0; i < len(replicaSetList.Items); i++ {
-					if getVersion(&replicaSetList.Items[i]) != maxVersion {
+					if version, _ := getVersion(&replicaSetList.Items[i]); version != maxVersion {
 						if replicaSetList.Items[i].Spec.Replicas != 0 {
 							return false
 						}

--- a/module-controller/internal/controller/moduledeployment_controller_suit_test.go
+++ b/module-controller/internal/controller/moduledeployment_controller_suit_test.go
@@ -6,7 +6,6 @@ import (
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
-	"github.com/sofastack/sofa-serverless/api/v1alpha1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
@@ -14,6 +13,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/sofastack/sofa-serverless/api/v1alpha1"
+
 	moduledeploymentv1alpha1 "github.com/sofastack/sofa-serverless/api/v1alpha1"
 	"github.com/sofastack/sofa-serverless/internal/constants/label"
 )

--- a/module-controller/internal/controller/moduledeployment_controller_suit_test.go
+++ b/module-controller/internal/controller/moduledeployment_controller_suit_test.go
@@ -67,7 +67,7 @@ var _ = Describe("ModuleDeployment Controller", func() {
 				maxVersion := 0
 				var newRS *moduledeploymentv1alpha1.ModuleReplicaSet
 				for i := 0; i < len(replicaSetList.Items); i++ {
-					version, err := getVersion(&replicaSetList.Items[i])
+					version, err := getRevision(&replicaSetList.Items[i])
 					if err != nil {
 						return false
 					}
@@ -79,7 +79,7 @@ var _ = Describe("ModuleDeployment Controller", func() {
 
 				// the replicas of old replicaset must be zero
 				for i := 0; i < len(replicaSetList.Items); i++ {
-					if version, _ := getVersion(&replicaSetList.Items[i]); version != maxVersion {
+					if version, _ := getRevision(&replicaSetList.Items[i]); version != maxVersion {
 						if replicaSetList.Items[i].Spec.Replicas != 0 {
 							return false
 						}

--- a/module-controller/internal/controller/moduledeployment_controller_suit_test.go
+++ b/module-controller/internal/controller/moduledeployment_controller_suit_test.go
@@ -138,7 +138,6 @@ func prepareModuleDeployment(namespace, moduleDeploymentName string) v1alpha1.Mo
 			},
 			SchedulingStrategy: v1alpha1.ModuleSchedulingStrategy{
 				SchedulingType: v1alpha1.Scatter,
-				MaxModuleCount: 10,
 			},
 		},
 		ObjectMeta: metav1.ObjectMeta{

--- a/module-controller/internal/controller/moduledeployment_controller_suit_test.go
+++ b/module-controller/internal/controller/moduledeployment_controller_suit_test.go
@@ -2,13 +2,17 @@ package controller
 
 import (
 	"context"
+	"time"
+
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	"github.com/sofastack/sofa-serverless/api/v1alpha1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
-	"time"
+
+	"github.com/sofastack/sofa-serverless/api/v1alpha1"
+	moduledeploymentv1alpha1 "github.com/sofastack/sofa-serverless/api/v1alpha1"
 )
 
 var _ = Describe("ModuleDeployment Controller", func() {

--- a/module-controller/internal/controller/moduledeployment_controller_suit_test.go
+++ b/module-controller/internal/controller/moduledeployment_controller_suit_test.go
@@ -18,7 +18,7 @@ import (
 	"github.com/sofastack/sofa-serverless/internal/constants/label"
 )
 
-var _ = FDescribe("ModuleDeployment Controller", func() {
+var _ = Describe("ModuleDeployment Controller", func() {
 	const timeout = time.Second * 30
 	const interval = time.Second * 5
 

--- a/module-controller/internal/controller/moduledeployment_controller_test.go
+++ b/module-controller/internal/controller/moduledeployment_controller_test.go
@@ -29,6 +29,6 @@ func TestIsModuleChanges(t *testing.T) {
 
 func TestGetModuleReplicasName(t *testing.T) {
 	moduleDeploymentName := "module-deployment"
-	reversion := 1
-	assert.Equal(t, fmt.Sprintf("%v-%v-%v", moduleDeploymentName, "replicas", reversion), getModuleReplicasName(moduleDeploymentName, reversion))
+	revision := 1
+	assert.Equal(t, fmt.Sprintf("%v-%v-%v", moduleDeploymentName, "replicas", revision), getModuleReplicasName(moduleDeploymentName, revision))
 }

--- a/module-controller/internal/controller/moduledeployment_controller_test.go
+++ b/module-controller/internal/controller/moduledeployment_controller_test.go
@@ -30,5 +30,5 @@ func TestIsModuleChanges(t *testing.T) {
 func TestGetModuleReplicasName(t *testing.T) {
 	moduleDeploymentName := "module-deployment"
 	reversion := 1
-	assert.Equal(t, fmt.Sprintf("moduleDeploymentName-%v-%v", "replicas", reversion), getModuleReplicasName(moduleDeploymentName, reversion))
+	assert.Equal(t, fmt.Sprintf("%v-%v-%v", moduleDeploymentName, "replicas", reversion), getModuleReplicasName(moduleDeploymentName, reversion))
 }

--- a/module-controller/internal/controller/moduledeployment_controller_test.go
+++ b/module-controller/internal/controller/moduledeployment_controller_test.go
@@ -1,9 +1,12 @@
 package controller
 
 import (
-	moduledeploymentv1alpha1 "github.com/sofastack/sofa-serverless/api/v1alpha1"
-	"github.com/stretchr/testify/assert"
+	"fmt"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	moduledeploymentv1alpha1 "github.com/sofastack/sofa-serverless/api/v1alpha1"
 )
 
 func TestIsModuleChanges(t *testing.T) {
@@ -26,5 +29,6 @@ func TestIsModuleChanges(t *testing.T) {
 
 func TestGetModuleReplicasName(t *testing.T) {
 	moduleDeploymentName := "module-deployment"
-	assert.Equal(t, moduleDeploymentName+"-replicas", getModuleReplicasName(moduleDeploymentName))
+	reversion := 1
+	assert.Equal(t, fmt.Sprintf("moduleDeploymentName-%v-%v", "replicas", reversion), getModuleReplicasName(moduleDeploymentName, reversion))
 }

--- a/module-controller/internal/controller/modulereplicaset_controller.go
+++ b/module-controller/internal/controller/modulereplicaset_controller.go
@@ -22,6 +22,7 @@ import (
 	"sort"
 	"strconv"
 
+	"golang.org/x/tools/container/intsets"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -325,7 +326,8 @@ func (r *ModuleReplicaSetReconciler) getScaleUpCandidatePods(
 	maxModuleCountLabel := selectedPods.Items[0].Labels[label.MaxModuleCount]
 	maxModuleCount, err := strconv.Atoi(maxModuleCountLabel)
 	if err != nil {
-		return nil, err
+		// if we get MaxModuleCount failed from pod, then set it to max
+		maxModuleCount = intsets.MaxInt
 	}
 
 	if strategy == moduledeploymentv1alpha1.Scatter {

--- a/module-controller/internal/controller/modulereplicaset_controller.go
+++ b/module-controller/internal/controller/modulereplicaset_controller.go
@@ -322,7 +322,7 @@ func (r *ModuleReplicaSetReconciler) getScaleUpCandidatePods(
 	strategyLabel := moduleReplicaSet.Labels[label.ModuleSchedulingStrategy]
 	strategy := moduledeploymentv1alpha1.ModuleSchedulingType(strategyLabel)
 
-	maxModuleCountLabel := moduleReplicaSet.Labels[label.MaxModuleCount]
+	maxModuleCountLabel := selectedPods.Items[0].Labels[label.MaxModuleCount]
 	maxModuleCount, err := strconv.Atoi(maxModuleCountLabel)
 	if err != nil {
 		return nil, err

--- a/module-controller/internal/controller/modulereplicaset_controller.go
+++ b/module-controller/internal/controller/modulereplicaset_controller.go
@@ -111,9 +111,7 @@ func (r *ModuleReplicaSetReconciler) Reconcile(ctx context.Context, req ctrl.Req
 	}
 	if expReplicas != moduleReplicaSet.Status.Replicas {
 		moduleReplicaSet.Status.Replicas = expReplicas
-		if err = r.Status().Update(ctx, moduleReplicaSet); err != nil {
-			return ctrl.Result{}, err
-		}
+		return ctrl.Result{}, r.Status().Update(ctx, moduleReplicaSet)
 	}
 
 	if moduleReplicaSet.DeletionTimestamp != nil {

--- a/module-controller/internal/controller/modulereplicaset_controller_suit_test.go
+++ b/module-controller/internal/controller/modulereplicaset_controller_suit_test.go
@@ -58,7 +58,9 @@ var _ = Describe("ModuleReplicaSet Controller", func() {
 			var newModuleReplicaSet v1alpha1.ModuleReplicaSet
 			k8sClient.Get(context.TODO(), key, &newModuleReplicaSet)
 			newModuleReplicaSet.Spec.Template.Spec.Module.Version = "1.0.1"
-			Expect(k8sClient.Update(context.TODO(), &newModuleReplicaSet)).Should(Succeed())
+			Eventually(func() bool {
+				return k8sClient.Update(context.TODO(), &newModuleReplicaSet) == nil
+			}, timeout, interval).Should(BeTrue())
 			Eventually(func() bool {
 				selector, err := metav1.LabelSelectorAsSelector(&newModuleReplicaSet.Spec.Selector)
 				modules := &v1alpha1.ModuleList{}

--- a/module-controller/internal/controller/modulereplicaset_controller_test.go
+++ b/module-controller/internal/controller/modulereplicaset_controller_test.go
@@ -73,14 +73,14 @@ func TestModuleReplicaSetReconciler_getScaleUpCandidatePods(t *testing.T) {
 	}{
 		{
 			targetModuleName: targetModuleName,
-			moduleReplicaSet: generateModuleReplicaSet(v1alpha1.Scatter, 2, 3),
+			moduleReplicaSet: generateModuleReplicaSet(v1alpha1.Scatter, 2),
 			podList:          podList,
 			moduleList:       moduleList,
 			expectedPodNames: []string{"pod-01"},
 		},
 		{
 			targetModuleName: targetModuleName,
-			moduleReplicaSet: generateModuleReplicaSet(v1alpha1.Stacking, 2, 3),
+			moduleReplicaSet: generateModuleReplicaSet(v1alpha1.Stacking, 2),
 			podList:          podList,
 			moduleList:       moduleList,
 			expectedPodNames: []string{"pod-03"},
@@ -127,14 +127,14 @@ func TestModuleReplicaSetReconciler_getScaleDownCandidateModules(t *testing.T) {
 	}{
 		{
 			targetModuleName: targetModuleName,
-			moduleReplicaSet: generateModuleReplicaSet(v1alpha1.Scatter, 1, 3),
+			moduleReplicaSet: generateModuleReplicaSet(v1alpha1.Scatter, 1),
 			podList:          podList,
 			moduleList:       moduleList,
 			expectedModules:  []string{targetModuleName + "/" + "pod-04"},
 		},
 		{
 			targetModuleName: targetModuleName,
-			moduleReplicaSet: generateModuleReplicaSet(v1alpha1.Stacking, 1, 3),
+			moduleReplicaSet: generateModuleReplicaSet(v1alpha1.Stacking, 1),
 			podList:          podList,
 			moduleList:       moduleList,
 			expectedModules:  []string{targetModuleName + "/" + "pod-03"},
@@ -175,6 +175,7 @@ func generatePodList(pods []podWithModules) *corev1.PodList {
 				Name: pod.podName,
 				Labels: map[string]string{
 					label.ModuleInstanceCount: strconv.FormatInt(int64(len(pod.modules)), 10),
+					label.MaxModuleCount:      "3",
 				},
 			},
 		})
@@ -205,12 +206,11 @@ func generateModuleList(moduleName string, pods []podWithModules) *v1alpha1.Modu
 }
 
 // generate moduleReplicaSet
-func generateModuleReplicaSet(strategy v1alpha1.ModuleSchedulingType, replicas, maxModuleCount int) *v1alpha1.ModuleReplicaSet {
+func generateModuleReplicaSet(strategy v1alpha1.ModuleSchedulingType, replicas int) *v1alpha1.ModuleReplicaSet {
 	return &v1alpha1.ModuleReplicaSet{
 		ObjectMeta: metav1.ObjectMeta{
 			Labels: map[string]string{
 				label.ModuleSchedulingStrategy: string(strategy),
-				label.MaxModuleCount:           strconv.Itoa(maxModuleCount),
 			},
 		},
 		Spec: v1alpha1.ModuleReplicaSetSpec{

--- a/module-controller/internal/controller/suite_test.go
+++ b/module-controller/internal/controller/suite_test.go
@@ -173,7 +173,7 @@ func preparePod(podName string) corev1.Pod {
 			Labels: map[string]string{
 				"app":                     "dynamic-stock",
 				label.ModuleInstanceCount: "0",
-				label.MaxModuleCount:      "10",
+				label.MaxModuleCount:      "3",
 			},
 		},
 		Spec: corev1.PodSpec{

--- a/module-controller/internal/controller/suite_test.go
+++ b/module-controller/internal/controller/suite_test.go
@@ -173,6 +173,7 @@ func preparePod(podName string) corev1.Pod {
 			Labels: map[string]string{
 				"app":                     "dynamic-stock",
 				label.ModuleInstanceCount: "0",
+				label.MaxModuleCount:      "10",
 			},
 		},
 		Spec: corev1.PodSpec{


### PR DESCRIPTION
### Description

支持自定义分组发布策略

测试结果如下所示，将一个 3 副本的 `module deployment`并分三组部署到 pod 上，并在 Status 可以看到每一个批次的状态信息
```
➜  module-controller git:(feat/batchDeploy) ✗ k describe moduledeployment moduledeployment-sample
...
Status:
  Conditions:
    last_transition_time:  2023-09-19T15:17:53Z
    Message:               deployment release: curbatch 1, batchCount 3
    Status:                True
    Type:                  Progressing
    last_transition_time:  2023-09-19T15:17:53Z
    Message:               deployment release: curbatch 2, batchCount 3
    Status:                True
    Type:                  Progressing
    last_transition_time:  2023-09-19T15:17:53Z
    Message:               deployment release: curbatch 3, batchCount 3
    Status:                True
    Type:                  Progressing
    last_transition_time:  2023-09-19T15:17:53Z
    Message:               deployment release progress completed
    Status:                True
    Type:                  Available
  Release Status:
    Current Batch:         4
    Last Transition Time:  2023-09-19T15:17:53Z
    Progress:              Completed

```
#### 发生版本变更时
```
# 创建第一次发布
➜ k apply -f config/samples/module-deployment_v1alpha1_moduledeployment.yaml
moduledeployment.serverless.alipay.com/moduledeployment-sample created

➜ k get moduledeployment && k get modulereplicaset && k get  module
NAME                      AGE
moduledeployment-sample   41s
NAME                                 AGE
moduledeployment-sample-replicas-1   41s
NAME                                                        AGE
moduledeployment-sample-replicas-1-dynamic-provider-57zmn   40s
moduledeployment-sample-replicas-1-dynamic-provider-6jzjb   40s
moduledeployment-sample-replicas-1-dynamic-provider-zfjq4   41s

# 更新版本重新apply
➜ k apply -f config/samples/module-deployment_v1alpha1_moduledeployment.yaml
moduledeployment.serverless.alipay.com/moduledeployment-sample configured

➜ k get moduledeployment && k get modulereplicaset && k get  module         
NAME                      AGE
moduledeployment-sample   66s
NAME                                 AGE
moduledeployment-sample-replicas-1   66s
moduledeployment-sample-replicas-2   4s
NAME                                                        AGE
moduledeployment-sample-replicas-1-dynamic-provider-57zmn   65s
moduledeployment-sample-replicas-1-dynamic-provider-6jzjb   65s
moduledeployment-sample-replicas-1-dynamic-provider-zfjq4   66s
moduledeployment-sample-replicas-2-dynamic-provider-8t2g9   3s
moduledeployment-sample-replicas-2-dynamic-provider-dhmf9   3s
moduledeployment-sample-replicas-2-dynamic-provider-pm7rh   3s

# old replicaset 自动清除
➜ k get moduledeployment && k get modulereplicaset && k get  module
NAME                      AGE
moduledeployment-sample   107s
NAME                                 AGE
moduledeployment-sample-replicas-1   107s
moduledeployment-sample-replicas-2   45s
NAME                                                        AGE
moduledeployment-sample-replicas-2-dynamic-provider-8t2g9   44s
moduledeployment-sample-replicas-2-dynamic-provider-dhmf9   44s
moduledeployment-sample-replicas-2-dynamic-provider-pm7rh   44s

```

ref: #21 