### PR TITLE
show modules & bases information

### DIFF
--- a/arkctl/cmd/show.go
+++ b/arkctl/cmd/show.go
@@ -22,6 +22,9 @@ import (
 	"github.com/spf13/cobra"
 )
 
+var moduleName string
+var baseName string
+
 // showCmd represents the show command
 var showCmd = &cobra.Command{
 	Use:   "show",
@@ -35,9 +38,87 @@ func init() {
 	showCmd.Flags().String("r", "", "")
 	showCmd.Flags().String("mc", "", "Get Metadata in MetadataCenter")
 	showCmd.Flags().String("h", "h", "")
+	showCmd.Flags().StringVarP(&moduleName, "module", "m", "", "Shows the modules information and status")
+	showCmd.Flags().StringVarP(&baseName, "base", "b", "", "Shows the modules on the base and their status")
 }
 
 func show(cmd *cobra.Command, _ []string) {
+
+	var moduleStatus map[string]string
+	var bases map[string][]string
+
 	fmt.Printf("======================\n")
-	fmt.Printf("获取模块状态信息")
+	// fmt.Printf("获取模块状态信息")
+
+	moduleStatus = getModuleStatus()
+	bases = getBases()
+
+	// Check for the presence of a module or base
+	_, existsBase := bases[baseName]
+	_, existsModule := moduleStatus[moduleName]
+
+	if !existsBase || !existsModule {
+		if !existsBase && baseName != "" {
+			fmt.Printf("[ERROR]：Base %s does not exist.\n", baseName)
+		}
+		if !existsModule && moduleName != "" {
+			fmt.Printf("[ERROR]：Module %s does not exist.\n", moduleName)
+		}
+	}
+
+	// Displays information about the module or base
+	if existsBase && existsModule {
+		// Look for the correct base where the module is located
+		if contains(bases[baseName], moduleName) {
+			fmt.Printf("Module: %s (Status: %s)\n", moduleName, moduleStatus[moduleName])
+		} else {
+			// Locate the correct base where the module is located
+			correctBase := ""
+			for base, modules := range bases {
+				if contains(modules, moduleName) {
+					correctBase = base
+					break
+				}
+			}
+			fmt.Printf("Module %s is not on base %s. It is located on base %s (Status: %s)\n", moduleName, baseName, correctBase, moduleStatus[moduleName])
+		}
+	} else if existsModule {
+		// Displays the base on which the module is located and its health
+		for base, modules := range bases {
+			if contains(modules, moduleName) {
+				fmt.Printf("Module: %s is on Base: %s (Status: %s)\n", moduleName, base, moduleStatus[moduleName])
+				continue
+			}
+		}
+	} else if existsBase {
+		// Displays the number of all modules on the base and the health of the modules
+		fmt.Printf("Base: %s contains %d modules\n", baseName, len(bases[baseName]))
+		for _, module := range bases[baseName] {
+			fmt.Printf("- Module: %s (Status: %s)\n", module, moduleStatus[module])
+		}
+	} else {
+		fmt.Printf("Please give the correct base name or module name.\n")
+	}
+}
+
+// Check if the slice contains a string
+func contains(slice []string, item string) bool {
+	for _, s := range slice {
+		if s == item {
+			return true
+		}
+	}
+	return false
+}
+
+// get modules status information
+func getModuleStatus() map[string]string {
+	var modulestatus = make(map[string]string)
+	return modulestatus
+}
+
+// get base information
+func getBases() map[string][]string {
+	var base = make(map[string][]string)
+	return base
 }


### PR DESCRIPTION
### Motivation

可以通过模块名或是基座名查询基本的信息

### Modification

1、通过模型名可以查询所在基座以及模块的健康状况
2、通过基座名可以查询基座上的模块数量以及健康状况
3、同时输入模块和基座名仅返回模块的健康状况
4、对于上述过程的输入异常（模块基座名称不存在，模块和基座不匹配）会产生具体的原因的报错

### Result

Resolved or fixed #84 . 
