### PR TITLE
arklet and sofaark 日志配置支持 logging.file.path 

### DIFF
--- a/samples/dubbo-samples/rpc/dubbo26/dubbo26base/src/main/resources/application.properties
+++ b/samples/dubbo-samples/rpc/dubbo26/dubbo26base/src/main/resources/application.properties
@@ -1,6 +1,5 @@
 spring.application.name=base
-logging.file.path=./rpc/dubbo26/logs/
-logging.path=./rpc/dubbo26/logs/
+logging.file.path=./samples/dubbo-samples/rpc/dubbo26/logs/
 logging.level.root=info
 logging.level.com.alipay.sofa.rpc.dubbo26=debug
 logging.config=classpath:log4j2-spring.xml

--- a/samples/dubbo-samples/rpc/dubbo26/dubbo26biz/src/main/resources/application.properties
+++ b/samples/dubbo-samples/rpc/dubbo26/dubbo26biz/src/main/resources/application.properties
@@ -1,6 +1,5 @@
 spring.application.name=biz
-logging.file.path=./rpc/grpc/logs/
-logging.path=./rpc/grpc/logs/
+logging.file.path=./samples/dubbo-samples/rpc/dubbo26/logs/
 logging.level.com.alipay.sofa.rpc.grpc=DEBUG
 logging.level.root=INFO
 logging.level.com.alipay.sofa.arklet=INFO

--- a/samples/dubbo-samples/rpc/dubbo26/pom.xml
+++ b/samples/dubbo-samples/rpc/dubbo26/pom.xml
@@ -20,7 +20,7 @@
 		<dubbo.version>2.6.4</dubbo.version>
 		<spring.boot.version>2.7.16</spring.boot.version>
 		<sofa.ark.version>2.2.4-SNAPSHOT</sofa.ark.version>
-		<sofa.serverless.runtime.version>0.5.0</sofa.serverless.runtime.version>
+		<sofa.serverless.runtime.version>0.5.1</sofa.serverless.runtime.version>
 		<disruptor.version>3.4.2</disruptor.version>
 		<maven.compiler.plugin.version>3.8.1</maven.compiler.plugin.version>
 	</properties>

--- a/samples/dubbo-samples/rpc/dubbo3/dubbo3base/src/main/resources/application.yml
+++ b/samples/dubbo-samples/rpc/dubbo3/dubbo3base/src/main/resources/application.yml
@@ -14,8 +14,7 @@ spring:
     name: dubbo3base
 logging:
   file:
-    path: ./rpc/dubbo3/logs/
-  path: ./rpc/dubbo3/logs/
+    path: ./samples/dubbo-samples/rpc/dubbo3/logs/
   level:
     root: info
     com.alipay.sofa.rpc.dubbo3: debug

--- a/samples/dubbo-samples/rpc/dubbo3/grpcbiz/src/main/resources/application.properties
+++ b/samples/dubbo-samples/rpc/dubbo3/grpcbiz/src/main/resources/application.properties
@@ -1,6 +1,5 @@
 spring.application.name=grpcbiz
-logging.file.path=./rpc/dubbo3/logs/
-logging.path=./rpc/dubbo3/logs/
+logging.file.path=./samples/dubbo-samples/rpc/dubbo3/logs/
 logging.level.com.alipay.sofa.rpc.dubbo3.grpcbiz=DEBUG
 logging.level.root=INFO
 logging.level.com.alipay.sofa.arklet=INFO

--- a/samples/dubbo-samples/rpc/dubbo3/pom.xml
+++ b/samples/dubbo-samples/rpc/dubbo3/pom.xml
@@ -23,7 +23,7 @@
 		<dubbo.version>2.6.4</dubbo.version>
 		<spring.boot.version>2.7.16</spring.boot.version>
 		<sofa.ark.version>2.2.4-SNAPSHOT</sofa.ark.version>
-		<sofa.serverless.runtime.version>0.5.0</sofa.serverless.runtime.version>
+		<sofa.serverless.runtime.version>0.5.1</sofa.serverless.runtime.version>
 		<disruptor.version>3.4.2</disruptor.version>
 		<maven.compiler.plugin.version>3.8.1</maven.compiler.plugin.version>
 		<dubbo.version>3.1.11</dubbo.version>

--- a/samples/dubbo-samples/rpc/dubbo3/triplebiz/src/main/resources/application.properties
+++ b/samples/dubbo-samples/rpc/dubbo3/triplebiz/src/main/resources/application.properties
@@ -1,6 +1,5 @@
 spring.application.name=triplebiz
-logging.file.path=./rpc/dubbo3/logs/
-logging.path=./rpc/dubbo3/logs/
+logging.file.path=./samples/dubbo-samples/rpc/dubbo3/logs/
 logging.level.com.alipay.sofa.rpc.dubbo3.triplebiz=DEBUG
 logging.level.root=INFO
 logging.level.com.alipay.sofa.arklet=INFO

--- a/sofa-serverless-runtime/arklet-core/src/main/java/com/alipay/sofa/serverless/arklet/core/common/log/ArkletLoggerFactory.java
+++ b/sofa-serverless-runtime/arklet-core/src/main/java/com/alipay/sofa/serverless/arklet/core/common/log/ArkletLoggerFactory.java
@@ -28,7 +28,7 @@ public class ArkletLoggerFactory {
 
     private static final String ARKLET_DEFAULT_LOGGER_NAME = "com.alipay.sofa.arklet";
 
-    public static ArkletLogger  defaultLogger              = getLogger(ARKLET_DEFAULT_LOGGER_NAME);
+    public static ArkletLogger  defaultLogger;
 
     public static ArkletLogger getLogger(Class<?> clazz) {
         if (clazz == null) {
@@ -45,6 +45,9 @@ public class ArkletLoggerFactory {
     }
 
     public static ArkletLogger getDefaultLogger() {
+        if (defaultLogger == null) {
+            defaultLogger = getLogger(ARKLET_DEFAULT_LOGGER_NAME);
+        }
         return defaultLogger;
     }
 

--- a/sofa-serverless-runtime/arklet-springboot-starter/src/main/java/com/alipay/sofa/serverless/arklet/springboot/starter/listener/ArkletApplicationListener.java
+++ b/sofa-serverless-runtime/arklet-springboot-starter/src/main/java/com/alipay/sofa/serverless/arklet/springboot/starter/listener/ArkletApplicationListener.java
@@ -36,11 +36,6 @@ import org.springframework.context.event.ContextRefreshedEvent;
 @SuppressWarnings("rawtypes")
 public class ArkletApplicationListener implements ApplicationListener<ApplicationContextEvent> {
 
-    private static final ArkletLogger LOGGER         = ArkletLoggerFactory.getDefaultLogger();
-
-    private final CommandService      commandService = ArkletComponentRegistry
-                                                         .getCommandServiceInstance();
-
     @Override
     public void onApplicationEvent(ApplicationContextEvent event) {
         // 非基座应用直接跳过
@@ -48,9 +43,10 @@ public class ArkletApplicationListener implements ApplicationListener<Applicatio
             return;
         }
         if (event instanceof ContextRefreshedEvent) {
-            List<AbstractCommandHandler> handlers = commandService.listAllHandlers();
+            List<AbstractCommandHandler> handlers = ArkletComponentRegistry
+                    .getCommandServiceInstance().listAllHandlers();
             String commands = handlers.stream().map(s -> s.command().getId()).collect(Collectors.joining(", "));
-            LOGGER.info("total supported commands:{}", commands);
+            ArkletLoggerFactory.getDefaultLogger().info("total supported commands:{}", commands);
         }
     }
 }

--- a/sofa-serverless-runtime/sofa-serverless-common/src/main/java/com/alipay/sofa/serverless/common/spring/ServerlessEnvironmentPostProcessor.java
+++ b/sofa-serverless-runtime/sofa-serverless-common/src/main/java/com/alipay/sofa/serverless/common/spring/ServerlessEnvironmentPostProcessor.java
@@ -20,18 +20,24 @@ import com.alipay.sofa.ark.api.ArkClient;
 import org.apache.commons.lang3.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.env.EnvironmentPostProcessor;
 import org.springframework.core.Ordered;
 import org.springframework.core.env.ConfigurableEnvironment;
 import org.springframework.core.env.Environment;
 import org.springframework.core.env.MutablePropertySources;
+import org.springframework.core.env.PropertiesPropertySource;
 import org.springframework.core.env.PropertySource;
 import org.springframework.util.Assert;
 
 import java.io.File;
+import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Iterator;
+import java.util.Map;
+import java.util.Map.Entry;
+import java.util.Properties;
 import java.util.Set;
 import java.util.concurrent.atomic.AtomicReference;
 
@@ -48,12 +54,18 @@ public class ServerlessEnvironmentPostProcessor implements EnvironmentPostProces
     // 框架定义的允许共享的配置列表
     private static final Set<String>                  DEFAULT_SHARE_KEYS                         = new HashSet<>();
 
+    private static final Map<String, String>          COMPATIBLE_KEYS                            = new HashMap<>();
+
     // 允许用户扩展的配置列表
     private static final String                       ENV_SHARE_KEY                              = "ark.common.env.share.keys";
     private static final String                       MASTER_BIZ_PROPERTIES_PROPERTY_SOURCE_NAME = "MasterBiz-Config resource";
     private static final Set<String>                  BASE_APP_SHARE_ENV_KEYS                    = new HashSet<>();
 
     private static final AtomicReference<Environment> MASTER_ENV                                 = new AtomicReference<>();
+
+    static {
+        COMPATIBLE_KEYS.put("logging.path", "logging.file.path");
+    }
 
     @Override
     public void postProcessEnvironment(ConfigurableEnvironment environment, SpringApplication application) {
@@ -74,7 +86,8 @@ public class ServerlessEnvironmentPostProcessor implements EnvironmentPostProces
                 while (iterator.hasNext()) {
                     PropertySource<?> next = iterator.next();
                     String psName = next.getName();
-                    if (StringUtils.contains(psName, getCanonicalPath(configLocation)) || StringUtils.contains(psName, getCanonicalPath(additionalLocation))) {
+                    if (StringUtils.contains(psName, getCanonicalPath(configLocation)) || StringUtils.contains(psName,
+                            getCanonicalPath(additionalLocation))) {
                         toRemove.add(psName);
                     }
                 }
@@ -94,6 +107,33 @@ public class ServerlessEnvironmentPostProcessor implements EnvironmentPostProces
         BASE_APP_SHARE_ENV_KEYS.addAll(org.springframework.util.StringUtils
             .commaDelimitedListToSet(environment.getProperty(ENV_SHARE_KEY)));
         MASTER_ENV.set(environment);
+        registerCompatibleProperty(environment);
+    }
+
+    /**
+     * 注册兼容性配置，如果没有配置oldKey，用newKey的值代替
+     * @param environment
+     */
+    private void registerCompatibleProperty(ConfigurableEnvironment environment) {
+        //构建 compatiblePropertySource，注册到 environment 中
+        Properties properties = new Properties();
+        for (Entry<String, String> entry : COMPATIBLE_KEYS.entrySet()) {
+            keepCompatible(environment, properties, entry.getKey(), entry.getValue());
+        }
+        PropertySource compatiblePropertySource = new PropertiesPropertySource(
+            "compatiblePropertySource", properties);
+        environment.getPropertySources().addLast(compatiblePropertySource);
+        getLogger().info("register compatiblePropertySource to env,{}", properties);
+    }
+
+    private void keepCompatible(ConfigurableEnvironment environment, Properties properties,
+                                String oldKey, String newKey) {
+        String oldValue = environment.getProperty(oldKey);
+        String newValue = environment.getProperty(newKey);
+        if (StringUtils.isBlank(oldValue) && StringUtils.isNotBlank(newValue)) {
+            //如果没有配置oldKey，用newKey的值代替
+            properties.put(oldKey, newValue);
+        }
     }
 
     private void registerMasterBizPropertySource(Environment masterEnv,

--- a/sofa-serverless-runtime/sofa-serverless-common/src/test/java/com/alipay/sofa/serverless/common/ServerlessEnvironmentPostProcessorTest.java
+++ b/sofa-serverless-runtime/sofa-serverless-common/src/test/java/com/alipay/sofa/serverless/common/ServerlessEnvironmentPostProcessorTest.java
@@ -55,6 +55,12 @@ public class ServerlessEnvironmentPostProcessorTest {
         // process master biz
         when(masterEnvironment.getProperty("ark.common.env.share.keys")).thenReturn("masterKey");
         when(masterEnvironment.getProperty("masterKey")).thenReturn("masterValue");
+        when(masterEnvironment.getProperty("logging.file.path")).thenReturn("./logs");
+        MutablePropertySources masterPropertySources = new MutablePropertySources();
+        masterPropertySources.addLast(new PropertiesPropertySource("masterProperties",
+            new Properties()));
+        when(masterEnvironment.getPropertySources()).thenReturn(masterPropertySources);
+
         ServerlessEnvironmentPostProcessor serverlessEnvironmentPostProcessor = new ServerlessEnvironmentPostProcessor();
         serverlessEnvironmentPostProcessor.postProcessEnvironment(masterEnvironment,
             springApplication);
@@ -86,5 +92,7 @@ public class ServerlessEnvironmentPostProcessorTest {
         PropertySource<?> masterPropertySource = propertySources.get("MasterBiz-Config resource");
         Assert.assertTrue(masterPropertySource instanceof MasterBizPropertySource);
         Assert.assertEquals("masterValue", masterPropertySource.getProperty("masterKey"));
+        Assert.assertEquals("./logs", masterPropertySources.get("compatiblePropertySource")
+            .getProperty("logging.path"));
     }
 }


### PR DESCRIPTION
### 需求
支持 #128 arklet and sofaark 日志配置支持 logging.file.path 

### 修改点
- ServerlessEnvironmentPostProcessor中新增一个“compatiblePropertySource”用于各种兼容性配置
- ArkletApplicationListener提前初始化了ArkletLogger导致一些配置使用了系统默认配置，调整到CommonLoggingApplicationListener之后
