### PR TITLE
fix log4j2, base log override by module

### DIFF
--- a/sofa-serverless-runtime/sofa-serverless-adapter-ext/sofa-serverless-adapter-log4j2/src/main/java/com/alipay/sofa/serverless/log4j2/SOFAServerlessLog4j2LoggingSystem.java
+++ b/sofa-serverless-runtime/sofa-serverless-adapter-ext/sofa-serverless-adapter-log4j2/src/main/java/com/alipay/sofa/serverless/log4j2/SOFAServerlessLog4j2LoggingSystem.java
@@ -131,8 +131,19 @@ public class SOFAServerlessLog4j2LoggingSystem extends Log4J2LoggingSystem {
         if (isAlreadyInitialized(loggerContext)) {
             return;
         }
-        super.beforeInitialize();
+        configureJdkLoggingBridgeHandler();
         loggerContext.getConfiguration().addFilter(FILTER);
+    }
+
+    private void configureJdkLoggingBridgeHandler() {
+        try {
+            if (this.isBridgeJulIntoSlf4j()) {
+                this.removeJdkLoggingBridgeHandler();
+                SLF4JBridgeHandler.install();
+            }
+        } catch (Throwable var2) {
+        }
+
     }
 
     @Override


### PR DESCRIPTION
## 问题描述
基座日志在模块安装后，会被模块影响，导致模块安装后基座日志无法在查看到。