### PR TITLE
升级fastjson版本1.2.69 到 1.2.83修复fastjson已知漏洞

### DIFF
--- a/sofa-serverless-runtime/pom.xml
+++ b/sofa-serverless-runtime/pom.xml
@@ -46,7 +46,7 @@
         <oshi.version>6.4.5</oshi.version>
         <commons.lang3.version>3.12.0</commons.lang3.version>
         <guava.version>32.1.2-jre</guava.version>
-        <fastjson.version>1.2.69</fastjson.version>
+        <fastjson.version>1.2.83</fastjson.version>
         <hessian.version>3.5.1</hessian.version>
     </properties>
 


### PR DESCRIPTION
升级fastjson版本1.2.69 到 1.2.83修复fastjson已知漏洞