### PR TITLE
fix bug 442，invoke producted method error

### DIFF
--- a/sofa-serverless-runtime/sofa-serverless-common/src/main/java/com/alipay/sofa/serverless/common/service/SpringServiceInvoker.java
+++ b/sofa-serverless-runtime/sofa-serverless-common/src/main/java/com/alipay/sofa/serverless/common/service/SpringServiceInvoker.java
@@ -145,7 +145,10 @@ public class SpringServiceInvoker implements MethodInterceptor {
 
     private Object invokeService(MethodInvocation invocation) throws InvocationTargetException,
                                                              IllegalAccessException {
-        return invocation.getMethod().invoke(target, invocation.getArguments());
+        Method method = invocation.getMethod();
+        //the method may be not public
+        method.setAccessible(true);
+        return method.invoke(target, invocation.getArguments());
     }
 
     private Method getTargetMethod(Method method, Class<?>[] argumentTypes) {


### PR DESCRIPTION
fix #442 
如果基座提供的bean被代理，业务模块通过@AutowrideFromBase获取bean，且引用的是实现类，而不是接口的情况下。
如果该bean有调用自身的producted方法，因为该bean被代理，会抛出无法访问的异常。
所以需要通过反射，强制允许该方法访问。